### PR TITLE
ci: upgrade deploy workflow to Node 22 and optimize pnpm/Vite caching

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -23,11 +23,14 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
-      - name: Enable Corepack (pnpm)
+      - name: Enable Corepack
         run: corepack enable
+
+      - name: Activate pnpm
+        run: corepack prepare pnpm@9 --activate
 
       - name: Cache Vite
         uses: actions/cache@v4
@@ -36,7 +39,7 @@ jobs:
           key: vite-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --prefer-offline
 
       - name: Build the website
         run: pnpm run build


### PR DESCRIPTION
- upgrade CI runtime to Node 22
- enable pnpm via Corepack
- add pnpm install optimization (--prefer-offline)
- cache Vite prebundled deps
- keep deterministic installs with frozen lockfile